### PR TITLE
feat: add new `environments` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,42 @@ pluginEslint({
 });
 ```
 
+### environments
+
+Control which environments to run ESLint on when using [Rsbuild's multi-environment builds](https://rsbuild.dev/guide/advanced/environments).
+
+- **Type:** `'all' | boolean | string[]`
+- **Default:** `false`
+- **Example:**
+
+By default, ESLint only runs on the first environment to avoid running multiple times:
+
+```js
+pluginEslint({
+  environments: false // (default)
+});
+```
+
+Run ESLint on all environments:
+
+```js
+pluginEslint({
+  environments: 'all',
+  // or
+  environments: true,
+});
+```
+
+Run ESLint on specific environments by name:
+
+```js
+pluginEslint({
+  environments: ['web', 'node'],
+});
+```
+
+This is useful when different environments have different entry points and you want to ensure all files are linted. Note that when set to `'all'` or `true`, ESLint will run separately for each environment, which may increase build time.
+
 ### eslintPluginOptions
 
 To modify the options of `eslint-rspack-plugin`, please refer to [eslint-rspack-plugin - README](https://github.com/rspack-contrib/eslint-rspack-plugin#readme) to learn about available options.


### PR DESCRIPTION
## Problem

When using Rsbuild's multi-environment builds feature, ESLint only runs on the first environment (index 0) to avoid duplicate runs. However, since ESLint only lints files in the compilation graph (files imported from entry points), files from other environments are never checked.

This means if different environments have different entry points, some source files may not be linted at all.

Fixes (?) https://github.com/rspack-contrib/rsbuild-plugin-eslint/issues/42

## Solution

Added a new `environments` option that allows controlling which environments ESLint runs on:

```typescript
type environments = 'all' | boolean | string[]
```

### Usage

```typescript
// Default - lint only first environment (current behavior)
pluginEslint()

// Lint all environments
pluginEslint({
  environments: 'all',  // or true
})

// Lint specific environments by name
pluginEslint({
  environments: ['web', 'node'],
})
```